### PR TITLE
fix(sonar): Toggle for Delete Project Props

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ docker run -d --name sonarqube -p 9000:9000 -p 9092:9092 sonarqube
 |SONAR_GITHUB_REPOSITORY| git org/repo eg. zotoio/gtm-agent|
 |SONAR_ANALYSIS_MODE| 'preview' used for pull requests |
 |SONAR_GITHUB_OAUTH| github personal access token|
+|SONAR_KEEP_PROJECT_PROPERTIES| If not `true`, delete any `sonar-project.properties` files in repo|
 |GIT_CLONE| git clone uri eg, https://github.com/org/repo.git|
 |GIT_PR_BRANCHNAME| branch name from PR event|
 |GIT_PR_ID| pull request number from PR event|

--- a/workspace/sonar.sh
+++ b/workspace/sonar.sh
@@ -2,8 +2,10 @@
 
 cd /usr/workspace/clone
 
-# Delete Sonar Properties as they Clash with the Pull Request Scan
-rm -f sonar-project.properties
+if [[ ! $SONAR_KEEP_PROJECT_PROPERTIES = 'true' ]]; then
+    # Delete Sonar Properties as they Clash with the Pull Request Scan
+    rm -f sonar-project.properties
+fi
 
 if [[ -n $SONAR_MODULES ]]; then
     SONAR_MODULES_PARAM=" -Dsonar.modules=$SONAR_MODULES "


### PR DESCRIPTION
@wyvern8 Thought it would be good to have this on a simple toggle so we can keep the file if the team wants to customise the scan.